### PR TITLE
Method names in Array class are inconsistent: Array#with(T), Array#without(int) and Array#less(T)

### DIFF
--- a/src/main/java/com/jcabi/immutable/Array.java
+++ b/src/main/java/com/jcabi/immutable/Array.java
@@ -177,7 +177,7 @@ public final class Array<T> implements List<T> {
     }
 
     /**
-     * Make a new array, without this element.
+     * Make a new array, without element on specific index.
      *
      * <p>The method throws {@link ArrayIndexOutOfBoundsException} if such
      * position is absent in the array.
@@ -185,7 +185,7 @@ public final class Array<T> implements List<T> {
      * @param idx The position to remove
      * @return New array
      */
-    public Array<T> without(final int idx) {
+    public Array<T> withoutIndex(final int idx) {
         if (idx >= this.values.length) {
             throw new ArrayIndexOutOfBoundsException(
                 String.format(
@@ -214,7 +214,7 @@ public final class Array<T> implements List<T> {
      * @return New array
      * @since 1.4
      */
-    public Array<T> less(final T item) {
+    public Array<T> without(final T item) {
         int idx = -1;
         for (int pos = 0; pos < this.values.length; ++pos) {
             if (this.values[pos].equals(item)) {
@@ -224,7 +224,7 @@ public final class Array<T> implements List<T> {
         }
         final Array<T> array;
         if (idx >= 0) {
-            array = this.without(idx);
+            array = this.withoutIndex(idx);
         } else {
             array = this;
         }

--- a/src/test/java/com/jcabi/immutable/ArrayTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayTest.java
@@ -90,9 +90,9 @@ public final class ArrayTest {
                 .with(Tv.FIVE)
                 .with(Tv.TEN)
                 .with(Tv.THOUSAND)
-                .without(0)
-                .without(0)
-                .without(0),
+                .withoutIndex(0)
+                .withoutIndex(0)
+                .withoutIndex(0),
             Matchers.empty()
         );
     }
@@ -108,9 +108,9 @@ public final class ArrayTest {
                 .with(Tv.FIVE)
                 .with(Tv.TEN)
                 .with(Tv.THOUSAND)
-                .less(Tv.FIVE)
-                .less(Tv.THREE)
-                .less(Tv.MILLION),
+                .without(Tv.FIVE)
+                .without(Tv.THREE)
+                .without(Tv.MILLION),
             Matchers.hasSize(2)
         );
     }


### PR DESCRIPTION
Renamed Array methods to avoid naming inconsistency.
For my opinion the right names are: Array#with(T), Array#without(T) and Array#withoutIndex(int)
Method name less is not really applicable here.
https://github.com/jcabi/jcabi-immutable/issues/22