### PR TITLE
Wrong use of generics in ArrayComparator#Reverse

### DIFF
--- a/src/main/java/com/jcabi/immutable/ArrayComparator.java
+++ b/src/main/java/com/jcabi/immutable/ArrayComparator.java
@@ -50,7 +50,8 @@ public interface ArrayComparator<T> extends Comparator<T> {
      * @param <T> Type of argument
      */
     @Immutable
-    final class Default<T> implements ArrayComparator<T>, Serializable {
+    final class Default<T extends Comparable<T>> implements ArrayComparator<T>,
+        Serializable {
         /**
          * Serialization marker.
          */
@@ -61,7 +62,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
         }
         @Override
         public int compare(final T left, final T right) {
-            return ((Comparable<T>) left).compareTo(right);
+            return left.compareTo(right);
         }
     }
 
@@ -90,8 +91,8 @@ public interface ArrayComparator<T> extends Comparator<T> {
      * @param <T> Type of argument
      */
     @Immutable
-    final class Reverse<T extends Comparable>
-        implements ArrayComparator<T>, Serializable {
+    final class Reverse<T extends Comparable<T>> implements ArrayComparator<T>,
+        Serializable {
         /**
          * Serialization marker.
          */

--- a/src/main/java/com/jcabi/immutable/ArrayComparator.java
+++ b/src/main/java/com/jcabi/immutable/ArrayComparator.java
@@ -50,7 +50,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
      * @param <T> Type of argument
      */
     @Immutable
-    final class Default<T extends Comparable<T>> implements ArrayComparator<T>,
+    final class Default<T> implements ArrayComparator<T>,
         Serializable {
         /**
          * Serialization marker.
@@ -62,7 +62,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
         }
         @Override
         public int compare(final T left, final T right) {
-            return left.compareTo(right);
+            return ((Comparable<T>) left).compareTo(right);
         }
     }
 

--- a/src/main/java/com/jcabi/immutable/ArrayComparator.java
+++ b/src/main/java/com/jcabi/immutable/ArrayComparator.java
@@ -50,8 +50,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
      * @param <T> Type of argument
      */
     @Immutable
-    final class Default<T> implements ArrayComparator<T>,
-        Serializable {
+    final class Default<T> implements ArrayComparator<T>, Serializable {
         /**
          * Serialization marker.
          */

--- a/src/main/java/com/jcabi/immutable/ArrayComparator.java
+++ b/src/main/java/com/jcabi/immutable/ArrayComparator.java
@@ -90,7 +90,8 @@ public interface ArrayComparator<T> extends Comparator<T> {
      * @param <T> Type of argument
      */
     @Immutable
-    final class Reverse<T> implements ArrayComparator<T>, Serializable {
+    final class Reverse<T extends Comparable>
+        implements ArrayComparator<T>, Serializable {
         /**
          * Serialization marker.
          */
@@ -101,7 +102,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
         }
         @Override
         public int compare(final T left, final T right) {
-            return ((Comparable<T>) right).compareTo(left);
+            return right.compareTo(left);
         }
     }
 

--- a/src/test/java/com/jcabi/immutable/ArrayComparatorTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayComparatorTest.java
@@ -46,7 +46,7 @@ public class ArrayComparatorTest {
      * @throws Exception If fails
      */
     @Test
-    private void reverseComparatorCanCompare() throws Exception {
+    public final void reverseComparatorCanCompare() throws Exception {
         final ArrayComparator.Reverse<Integer> comparator =
             new ArrayComparator.Reverse<Integer>();
         final int result = comparator.compare(1, 2);

--- a/src/test/java/com/jcabi/immutable/ArrayComparatorTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayComparatorTest.java
@@ -34,12 +34,12 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Test case for {@link ArrayComparator} implementations.
+ * Test case for {@link ArrayComparator}.
  * @author Igor Piddubnyi (igor.piddubnyi@gmail.com)
  * @version $Id$
- * @since 2.0
+ * @since 1.5
  */
-public class ArrayComparatorTest {
+public final class ArrayComparatorTest {
 
     /**
      * ReverseComparator can compare.
@@ -47,9 +47,9 @@ public class ArrayComparatorTest {
      */
     @Test
     public final void reverseComparatorCanCompare() throws Exception {
-        final ArrayComparator.Reverse<Integer> comparator =
-            new ArrayComparator.Reverse<Integer>();
-        final int result = comparator.compare(1, 2);
-        MatcherAssert.assertThat(result, Matchers.greaterThan(0));
+        MatcherAssert.assertThat(
+            new ArrayComparator.Reverse<Integer>().compare(1, 2),
+            Matchers.greaterThan(0)
+        );
     }
 }

--- a/src/test/java/com/jcabi/immutable/ArrayComparatorTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayComparatorTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.immutable;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Test case for {@link ArrayComparator} implementations.
+ * @author Igor Piddubnyi (igor.piddubnyi@gmail.com)
+ * @version $Id$
+ * @since 2.0
+ */
+public class ArrayComparatorTest {
+
+    /**
+     * ReverseComparator can compare.
+     * @throws Exception If fails
+     */
+    @Test
+    private void reverseComparatorCanCompare() throws Exception {
+        final ArrayComparator.Reverse<Integer> comparator =
+            new ArrayComparator.Reverse<Integer>();
+        final int result = comparator.compare(1, 2);
+        MatcherAssert.assertThat(result, Matchers.greaterThan(0));
+    }
+}

--- a/src/test/java/com/jcabi/immutable/ArrayComparatorTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayComparatorTest.java
@@ -46,7 +46,7 @@ public final class ArrayComparatorTest {
      * @throws Exception If fails
      */
     @Test
-    public final void reverseComparatorCanCompare() throws Exception {
+    public void reverseComparatorCanCompare() throws Exception {
         MatcherAssert.assertThat(
             new ArrayComparator.Reverse<Integer>().compare(1, 2),
             Matchers.greaterThan(0)

--- a/src/test/java/com/jcabi/immutable/ArrayTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayTest.java
@@ -197,12 +197,4 @@ public final class ArrayTest {
         );
     }
 
-    @Test
-    public void arrayComparatorWorksWithComparable() {
-        final ArrayComparator.Reverse<Integer> comparator =
-            new ArrayComparator.Reverse<Integer>();
-        final int result = comparator.compare(1, 2);
-        MatcherAssert.assertThat(result,Matchers.greaterThan(0));
-    }
-
 }

--- a/src/test/java/com/jcabi/immutable/ArrayTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayTest.java
@@ -197,4 +197,12 @@ public final class ArrayTest {
         );
     }
 
+    @Test
+    public void arrayComparatorWorksWithComparable() {
+        final ArrayComparator.Reverse<Integer> comparator =
+            new ArrayComparator.Reverse<Integer>();
+        final int result = comparator.compare(1, 2);
+        MatcherAssert.assertThat(result,Matchers.greaterThan(0));
+    }
+
 }


### PR DESCRIPTION
Solving https://github.com/jcabi/jcabi-immutable/issues/21
Changed generic usage to avoid wrong usage.