### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.org/jcabi/jcabi-immutable.svg?branch=master)](https://travis-ci.org/jcabi/jcabi-immutable)
 [![PDD status](http://www.0pdd.com/svg?name=jcabi/jcabi-immutable)](http://www.0pdd.com/p?name=jcabi/jcabi-immutable)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-immutable/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-immutable)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-immutable/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-immutable)
+[![Javadoc](https://javadoc.io/badge/com.jcabi/jcabi-immutable.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-immutable)
 [![Dependencies](https://www.versioneye.com/user/projects/561ac50ca193340f28001121/badge.svg?style=flat)](https://www.versioneye.com/user/projects/561ac50ca193340f28001121)
 
 More details are here: [immutable.jcabi.com](http://immutable.jcabi.com/index.html)


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io