### PR TITLE
Travis-CI builds passes with Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 sudo: false
+dist: trusty
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
This project uses an older version of oraclejdk8 and openjdk7 which causes the Travis Build to fail. 

**Solution:**
Changing the Linux Distro to an Older Version (Trusty) solves the problem. Travis CI build passed once I change the Linux Distro to an older version.

**This failure is caused by the following reasons:**
1. oraclejdk8: Oracle has changed their license terms and oraclejdk8 cannot be downloaded anymore without logging in.
2. openjdk7: Travis-CI uses the newer version of Linux Distro - Xenial, which I think does not support this version of OpenJDK.