### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/src/main/java/com/jcabi/immutable/package-info.java
+++ b/src/main/java/com/jcabi/immutable/package-info.java
@@ -40,7 +40,7 @@
  * &lt;/dependency&gt;</pre>
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @version $Id: f972643862b3175dc5b4dc07ae952c89091c0f27 $
  * @since 0.1.10
  * @see <a href="http://www.jcabi.com/jcabi-immutable">project website</a>
  */

--- a/src/test/java/com/jcabi/immutable/package-info.java
+++ b/src/test/java/com/jcabi/immutable/package-info.java
@@ -32,7 +32,7 @@
  * Simple immutable collections, maps, sets, etc.
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
- * @version $Id$
+ * @version $Id: 45b36256a1743cb62fe44848019cea9df280588d $
  * @since 0.1.10
  */
 package com.jcabi.immutable;


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
