### PR TITLE
Bump parent to 1.44.0 and qulice to 0.27.4

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,8 +12,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
@@ -24,7 +24,7 @@ jobs:
           restore-keys: |
             maven-
       - run: mvn install -Pjacoco
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/site/jacoco/jacoco.xml

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: yegor256/copyrights-action@0.0.12

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: DavidAnson/markdownlint-cli2-action@v20.0.0
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [21]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: volodya-lombrozo/pdd-action@master

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: fsfe/reuse-action@v5
+      - uses: actions/checkout@v6
+      - uses: fsfe/reuse-action@v6

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
-      - uses: crate-ci/typos@v1.35.4
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.45.1

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: g4s8/xcop-action@master

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ibiqlik/action-yamllint@v3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="https://www.jcabi.com/logo-square.svg" width="64px" height="64px" />
+# jcabi-immutable
+
+![jcabi logo](https://www.jcabi.com/logo-square.svg)
 
 [![EO principles respected here](https://www.elegantobjects.org/badge.svg)](https://www.elegantobjects.org)
 [![DevOps By Rultor.com](https://www.rultor.com/b/jcabi/jcabi-immutable)](https://www.rultor.com/p/jcabi/jcabi-immutable)
@@ -25,6 +27,6 @@ the `master` branch, if they look correct.
 
 Please run Maven build before submitting a pull request:
 
-```
-$ mvn clean install -Pqulice
+```bash
+mvn clean install -Pqulice
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.38.0</version>
+    <version>1.44.0</version>
   </parent>
   <artifactId>jcabi-immutable</artifactId>
   <version>2.0-SNAPSHOT</version>
@@ -74,7 +74,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.25.1</version>
+            <version>0.27.4</version>
             <configuration>
               <excludes>
                 <exclude>duplicatefinder:.*</exclude>

--- a/src/main/java/com/jcabi/immutable/Array.java
+++ b/src/main/java/com/jcabi/immutable/Array.java
@@ -6,11 +6,11 @@ package com.jcabi.immutable;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -20,14 +20,17 @@ import java.util.ListIterator;
  * <p>This class is truly immutable. This means that it never changes
  * its encapsulated values and is annotated with {@code @Immutable}
  * annotation.
- * <p>
- * Limitation:
+ *
+ * <p>Limitation:
  * Encapsulated objects with exposed mutators can mutate their state.
  *
  * @param <T> Value key type
  * @since 0.1
- * @checkstyle MissingDeprecatedCheck (430 lines)
  */
+// @checkstyle MissingDeprecatedCheck (430 lines)
+// @checkstyle ConstructorsCodeFreeCheck (430 lines)
+// @checkstyle ConstructorsOrderCheck (430 lines)
+// @checkstyle QualifyInnerClassCheck (430 lines)
 @Immutable
 @Loggable(Loggable.DEBUG)
 @SuppressWarnings({
@@ -67,7 +70,7 @@ public final class Array<T> implements List<T> {
      */
     public Array(final Iterable<T> list) {
         this.throwIfArgumentIsNull(list, "list of objects can't be NULL");
-        final Collection<T> items = new LinkedList<>();
+        final Collection<T> items = new ArrayList<>(0);
         for (final T item : list) {
             items.add(item);
         }
@@ -138,7 +141,7 @@ public final class Array<T> implements List<T> {
         this.throwIfArgumentIsNull(
             vals, "Iterable argument of Array#with() can't be NULL"
         );
-        final Collection<T> list = new LinkedList<>();
+        final Collection<T> list = new ArrayList<>(this.values.length);
         list.addAll(Arrays.asList(this.values));
         for (final T value : vals) {
             list.add(value);
@@ -272,6 +275,7 @@ public final class Array<T> implements List<T> {
     }
 
     @Override
+    @SuppressWarnings("TypeParameterShadowing")
     public <T> T[] toArray(final T[] array) {
         final T[] target;
         if (array.length == this.values.length) {

--- a/src/main/java/com/jcabi/immutable/ArrayComparator.java
+++ b/src/main/java/com/jcabi/immutable/ArrayComparator.java
@@ -10,7 +10,6 @@ import java.util.Comparator;
 
 /**
  * Comparator for arrays.
- *
  * @param <T> Value type
  * @since 1.0
  */
@@ -25,6 +24,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
      */
     @Immutable
     final class Default<T> implements ArrayComparator<T>, Serializable {
+
         /**
          * Serialization marker.
          */
@@ -48,6 +48,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
      */
     @Immutable
     final class Neutral<T> implements ArrayComparator<T>, Serializable {
+
         /**
          * Serialization marker.
          */
@@ -59,6 +60,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
         }
 
         @Override
+        @SuppressWarnings("UnusedVariable")
         public int compare(final T left, final T right) {
             return 1;
         }
@@ -72,6 +74,7 @@ public interface ArrayComparator<T> extends Comparator<T> {
     @Immutable
     final class Reverse<T extends Comparable<T>> implements ArrayComparator<T>,
         Serializable {
+
         /**
          * Serialization marker.
          */
@@ -87,5 +90,4 @@ public interface ArrayComparator<T> extends Comparator<T> {
             return right.compareTo(left);
         }
     }
-
 }

--- a/src/main/java/com/jcabi/immutable/ArrayMap.java
+++ b/src/main/java/com/jcabi/immutable/ArrayMap.java
@@ -21,20 +21,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
-* Map on top of array.
-*
+ * Map on top of array.
+ *
  * <p>This class is truly immutable. This means that it never changes
  * its encapsulated values and is annotated with {@code @Immutable}
  * annotation.
- * <p>
- * Limitation:
+ *
+ * <p>Limitation:
  * Encapsulated objects with exposed mutators can mutate their state.
  *
  * @param <K> Map key type
  * @param <V> Value key type
  * @since 0.1
- * @checkstyle MissingDeprecatedCheck (400 lines)
  */
+// @checkstyle MissingDeprecatedCheck (400 lines)
+// @checkstyle ConstructorsCodeFreeCheck (400 lines)
+// @checkstyle ConstructorsOrderCheck (400 lines)
+// @checkstyle QualifyInnerClassCheck (400 lines)
 @Immutable
 @Loggable(Loggable.DEBUG)
 @SuppressWarnings({
@@ -329,6 +332,7 @@ public final class ArrayMap<K, V> implements ConcurrentMap<K, V> {
      */
     private static final class Cmp<K, V> implements
         Comparator<ArrayMap.ImmutableEntry<K, V>>, Serializable {
+
         /**
          * The Serial version UID.
          */
@@ -358,6 +362,7 @@ public final class ArrayMap<K, V> implements ConcurrentMap<K, V> {
     @Immutable
     private static final class ImmutableEntry<K, V> extends
         AbstractMap.SimpleImmutableEntry<K, V> {
+
         /**
          * Serialization marker.
          */
@@ -385,5 +390,4 @@ public final class ArrayMap<K, V> implements ConcurrentMap<K, V> {
             return String.format("%s=%s", this.getKey(), this.getValue());
         }
     }
-
 }

--- a/src/main/java/com/jcabi/immutable/ArraySet.java
+++ b/src/main/java/com/jcabi/immutable/ArraySet.java
@@ -6,12 +6,12 @@ package com.jcabi.immutable;
 
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Loggable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Set;
 
 /**
@@ -20,17 +20,20 @@ import java.util.Set;
  * <p>This class is truly immutable. This means that it never changes
  * its encapsulated values and is annotated with {@code @Immutable}
  * annotation.
- * <p>
- * Limitations:
+ *
+ * <p>Limitations:
  * Encapsulated objects with exposed mutators can mutate their state.
  *
- * Since this Set implementation is backed by array,<br>
+ * <p>Since this Set implementation is backed by array,<br>
  * complexity of {@link ArraySet#contains} is (<b>O(n)</b>).
  *
  * @param <T> Value key type
  * @since 0.1
- * @checkstyle MissingDeprecatedCheck (270 lines)
  */
+// @checkstyle MissingDeprecatedCheck (270 lines)
+// @checkstyle ConstructorsCodeFreeCheck (270 lines)
+// @checkstyle ConstructorsOrderCheck (270 lines)
+// @checkstyle QualifyInnerClassCheck (270 lines)
 @Immutable
 @Loggable(Loggable.DEBUG)
 @SuppressWarnings({
@@ -136,7 +139,7 @@ public final class ArraySet<T> implements Set<T> {
         this.throwIfArgumentIsNull(
             value, "argument of ArraySet#without() can't be NULL"
         );
-        final Collection<T> list = new LinkedList<>();
+        final Collection<T> list = new ArrayList<>(this.size());
         list.addAll(this);
         list.remove(value);
         return new ArraySet<>(list);
@@ -202,6 +205,7 @@ public final class ArraySet<T> implements Set<T> {
     }
 
     @Override
+    @SuppressWarnings("TypeParameterShadowing")
     public <T> T[] toArray(final T[] array) {
         final T[] dest;
         if (array.length == this.values.length) {

--- a/src/main/java/com/jcabi/immutable/ArraySortedSet.java
+++ b/src/main/java/com/jcabi/immutable/ArraySortedSet.java
@@ -22,21 +22,26 @@ import java.util.TreeSet;
  * <p>This class is truly immutable. This means that it never changes
  * its encapsulated values and is annotated with {@code @Immutable}
  * annotation.
- * <p>
- * Limitation:
+ *
+ * <p>Limitation:
  * Encapsulated objects with exposed mutators can mutate their state.
  *
  * @param <T> Value key type
  * @since 0.1
- * @checkstyle MissingDeprecatedCheck (360 lines)
  */
+// @checkstyle MissingDeprecatedCheck (360 lines)
+// @checkstyle ConstructorsCodeFreeCheck (360 lines)
+// @checkstyle ConstructorsOrderCheck (360 lines)
+// @checkstyle QualifyInnerClassCheck (360 lines)
+// @checkstyle MethodDeclarationLengthCheck (360 lines)
 @Immutable
 @Loggable(Loggable.DEBUG)
 @SuppressWarnings({
     "unchecked", "PMD.TooManyMethods",
     "PMD.ConstructorOnlyInitializesOrCallOtherConstructors",
     "PMD.OnlyOneConstructorShouldDoInitialization",
-    "PMD.LooseCoupling", "PMD.GodClass"
+    "PMD.LooseCoupling", "PMD.GodClass",
+    "JdkObsolete"
 })
 public final class ArraySortedSet<T> implements SortedSet<T> {
 
@@ -292,6 +297,7 @@ public final class ArraySortedSet<T> implements SortedSet<T> {
     }
 
     @Override
+    @SuppressWarnings("TypeParameterShadowing")
     public <T> T[] toArray(final T[] array) {
         final T[] dest;
         if (array.length == this.values.length) {

--- a/src/main/java/com/jcabi/immutable/package-info.java
+++ b/src/main/java/com/jcabi/immutable/package-info.java
@@ -9,7 +9,7 @@
  * <p>The only dependency you need is (check our latest version available
  * at <a href="http://www.jcabi.com">www.jcabi.com</a>):
  *
- * <pre>&lt;depedency&gt;
+ * <pre>&lt;dependency&gt;
  *   &lt;groupId&gt;com.jcabi&lt;/groupId&gt;
  *   &lt;artifactId&gt;jcabi-immutable&lt;/artifactId&gt;
  * &lt;/dependency&gt;</pre>

--- a/src/test/java/com/jcabi/immutable/ArrayMapTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayMapTest.java
@@ -108,5 +108,4 @@ final class ArrayMapTest {
             Matchers.hasKey(10)
         );
     }
-
 }

--- a/src/test/java/com/jcabi/immutable/ArrayMapTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayMapTest.java
@@ -35,7 +35,7 @@ final class ArrayMapTest {
             new ArrayMap<Integer, String>()
                 .with(5, "four")
                 .with(5, Integer.toString(5))
-                .with(40, "fourty")
+                .with(40, "forty")
                 .without(40)
                 .with(10, "ten"),
             Matchers.allOf(

--- a/src/test/java/com/jcabi/immutable/ArraySetTest.java
+++ b/src/test/java/com/jcabi/immutable/ArraySetTest.java
@@ -4,9 +4,9 @@
  */
 package com.jcabi.immutable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ final class ArraySetTest {
 
     @Test
     void worksAsANormalSortedSetContainingItems() {
-        final Collection<Integer> list = new LinkedList<>();
+        final Collection<Integer> list = new ArrayList<>(2);
         list.add(10);
         list.add(5);
         MatcherAssert.assertThat(
@@ -31,7 +31,7 @@ final class ArraySetTest {
 
     @Test
     void worksAsANormalSortedSetWithCorrectSize() {
-        final Collection<Integer> list = new LinkedList<>();
+        final Collection<Integer> list = new ArrayList<>(2);
         list.add(10);
         list.add(5);
         MatcherAssert.assertThat(
@@ -75,5 +75,4 @@ final class ArraySetTest {
             Matchers.hasItem(10)
         );
     }
-
 }

--- a/src/test/java/com/jcabi/immutable/ArraySortedSetTest.java
+++ b/src/test/java/com/jcabi/immutable/ArraySortedSetTest.java
@@ -134,5 +134,4 @@ final class ArraySortedSetTest {
             Matchers.contains("A short text", "B very long long text")
         );
     }
-
 }

--- a/src/test/java/com/jcabi/immutable/ArrayTest.java
+++ b/src/test/java/com/jcabi/immutable/ArrayTest.java
@@ -4,9 +4,9 @@
  */
 package com.jcabi.immutable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -20,7 +20,7 @@ final class ArrayTest {
 
     @Test
     void worksAsANormalArrayContainingItems() {
-        final Collection<Integer> list = new LinkedList<>();
+        final Collection<Integer> list = new ArrayList<>(2);
         list.add(10);
         list.add(5);
         MatcherAssert.assertThat(
@@ -32,7 +32,7 @@ final class ArrayTest {
 
     @Test
     void worksAsANormalArrayWithCorrectSize() {
-        final Collection<Integer> list = new LinkedList<>();
+        final Collection<Integer> list = new ArrayList<>(2);
         list.add(10);
         list.add(5);
         MatcherAssert.assertThat(
@@ -176,5 +176,4 @@ final class ArrayTest {
             Matchers.is(true)
         );
     }
-
 }

--- a/src/test/java/com/jcabi/immutable/package-info.java
+++ b/src/test/java/com/jcabi/immutable/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Simple immutable collections, maps, sets, etc.
- *
  * @since 0.1.10
  */
 package com.jcabi.immutable;


### PR DESCRIPTION
@yegor256 this PR brings `jcabi-immutable` in line with the current jcabi baseline (matching `jcabi-urn`). All 11 CI jobs are green; ready for review.

## What changed

**Dependency / build upgrades**

- `com.jcabi:jcabi` parent: `1.38.0` → `1.44.0`
- `com.qulice:qulice-maven-plugin`: `0.25.1` → `0.27.4`
- CI matrix: drop JDK 11 / 17, keep JDK 21 only (qulice 0.27.x requires JDK 21)
- GitHub Actions versions aligned with `jcabi-urn`: `actions/checkout@v6`, `actions/setup-java@v5`, `codecov/codecov-action@v6`, `fsfe/reuse-action@v6`, `crate-ci/typos@v1.45.1`, `DavidAnson/markdownlint-cli2-action@v23`

**Source — real fixes for the new qulice rules**

- `LinkedList` → `ArrayList` in `Array`, `ArraySet`, `ArrayTest`, `ArraySetTest` (the `LinkedList`-specific API was never used) — addresses ErrorProne `JdkObsolete`.
- Cleaned up javadoc `<p>` tags and removed empty Javadoc lines before single-paragraph `@`-clauses (`JavadocEmptyLineBeforeTagCheck`).
- Added the missing blank line before the first member of two nested classes in `ArrayMap` (`EmptyLineBeforeFirstMemberCheck`); removed empty lines before closing braces in source and tests (`RegexpMultilineCheck`); reordered imports where `ArrayList` was added (`ImportOrderCheck`).

**Source — narrow, justified suppressions**

New qulice rules that fire pervasively across already-correct code are suppressed at the class level via inline `// @checkstyle …` comments (kept consistent with how `jcabi-urn` declares them inline rather than as javadoc block tags so ErrorProne's `InvalidBlockTag` does not fire). Specifically:

- `ConstructorsCodeFreeCheck`, `ConstructorsOrderCheck`, `QualifyInnerClassCheck` on the four collection classes — required by the immutable `System.arraycopy`/`new Foo<>(…)` constructor pattern these classes are built on.
- `MethodDeclarationLengthCheck` on `ArraySortedSet` for the same reason.
- `@SuppressWarnings("TypeParameterShadowing")` on each `Collection.toArray(T[])` override — the shadowing is required by the JDK contract.
- `@SuppressWarnings("JdkObsolete")` on `ArraySortedSet` — `SortedSet` is part of its declared API.
- `@SuppressWarnings("UnusedVariable")` on `ArrayComparator.Neutral.compare` — the parameters are required by the `Comparator` contract.

**Pre-existing CI failures fixed too**

The newer linter versions surfaced pre-existing issues that I went ahead and fixed:

- `README.md`: added a top-level heading, replaced the bare `<img>` with a markdown image (alt text included), and tagged the fenced code block as `bash` without a leading `$` (resolves MD033, MD041, MD045, MD040, MD014).
- Two typos: `depedency` → `dependency` (`package-info.java`) and `fourty` → `forty` (`ArrayMapTest`), both flagged by `crate-ci/typos@v1.45.1`.

## Verification

- `mvn --batch-mode clean install -Pqulice` passes locally on JDK 21.
- All 11 CI jobs green on the latest commit (mvn × ubuntu/windows/macos, plus actionlint, codecov, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint).

Three small commits, each independently buildable. Tagging you for review, @yegor256.